### PR TITLE
refactor: remove local character storage

### DIFF
--- a/apps/web/src/app/creator/CharacterCreator.tsx
+++ b/apps/web/src/app/creator/CharacterCreator.tsx
@@ -1,7 +1,12 @@
 'use client';
 import { useEffect, useRef, useState } from 'react';
 import { CharacterSprite, CharacterAppearance } from '../../lib/sprites/characterSprites';
-import { CHARACTER_OPTIONS, saveCharacterAppearance, loadCharacterAppearance } from '../../lib/sprites/characterOptions';
+import {
+  CHARACTER_OPTIONS,
+  saveCharacterAppearance,
+  loadCharacterAppearance,
+  loadCharacterAppearanceAsync
+} from '../../lib/sprites/characterOptions';
 
 export default function CharacterCreator() {
   const [appearance, setAppearance] = useState<CharacterAppearance>(loadCharacterAppearance());
@@ -16,6 +21,15 @@ export default function CharacterCreator() {
   useEffect(() => {
     loadSprite();
   }, [appearance]);
+
+  useEffect(() => {
+    const loadFromDb = async () => {
+      const dbAppearance = await loadCharacterAppearanceAsync();
+      setAppearance(dbAppearance);
+      setName(dbAppearance.name || 'Trader');
+    };
+    loadFromDb();
+  }, []);
 
   useEffect(() => {
     console.log('Setting animation:', animationType, direction);

--- a/apps/web/src/app/creator/CharacterCreator.tsx
+++ b/apps/web/src/app/creator/CharacterCreator.tsx
@@ -4,29 +4,36 @@ import { CharacterSprite, CharacterAppearance } from '../../lib/sprites/characte
 import {
   CHARACTER_OPTIONS,
   saveCharacterAppearance,
-  loadCharacterAppearance,
   loadCharacterAppearanceAsync
 } from '../../lib/sprites/characterOptions';
 
 export default function CharacterCreator() {
-  const [appearance, setAppearance] = useState<CharacterAppearance>(loadCharacterAppearance());
-  const [name, setName] = useState<string>(appearance.name || 'Trader');
+  const [appearance, setAppearance] = useState<CharacterAppearance | null>(null);
+  const [name, setName] = useState<string>('Trader');
   const [sprite, setSprite] = useState<CharacterSprite | null>(null);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [animationType, setAnimationType] = useState<'idle' | 'walk' | 'run'>('idle');
   const [direction, setDirection] = useState<'south' | 'west' | 'east' | 'north'>('south');
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const animationRef = useRef<number | undefined>(undefined);
 
   useEffect(() => {
-    loadSprite();
+    if (appearance) {
+      loadSprite();
+    }
   }, [appearance]);
 
   useEffect(() => {
     const loadFromDb = async () => {
-      const dbAppearance = await loadCharacterAppearanceAsync();
-      setAppearance(dbAppearance);
-      setName(dbAppearance.name || 'Trader');
+      try {
+        const dbAppearance = await loadCharacterAppearanceAsync();
+        setAppearance(dbAppearance);
+        setName(dbAppearance.name || 'Trader');
+      } catch (error) {
+        console.error('Failed to load character from database:', error);
+      } finally {
+        setLoading(false);
+      }
     };
     loadFromDb();
   }, []);
@@ -39,6 +46,7 @@ export default function CharacterCreator() {
   }, [sprite, animationType, direction]);
 
   async function loadSprite() {
+    if (!appearance) return;
     setLoading(true);
     console.log('Loading sprite with appearance:', appearance);
     try {
@@ -100,10 +108,12 @@ export default function CharacterCreator() {
   }, []);
 
   function updateAppearance(key: keyof CharacterAppearance, value: string) {
-    setAppearance(prev => ({ ...prev, [key]: value }));
+    if (!appearance) return;
+    setAppearance(prev => ({ ...prev!, [key]: value }));
   }
 
   async function save() {
+    if (!appearance) return;
     const fullAppearance = { ...appearance, name };
     try {
       await saveCharacterAppearance(fullAppearance);
@@ -112,6 +122,10 @@ export default function CharacterCreator() {
       console.error('Failed to save character:', error);
       alert('Failed to save character. Please try again.');
     }
+  }
+
+  if (loading || !appearance) {
+    return <div>Loading character...</div>;
   }
 
   return (

--- a/apps/web/src/components/GameLayout.tsx
+++ b/apps/web/src/components/GameLayout.tsx
@@ -46,17 +46,16 @@ export default function GameLayout({
         // First try to load from database
         const { loadCharacterFromDatabase } = await import('@/lib/sprites/characterDatabase');
         const dbAppearance = await loadCharacterFromDatabase();
-        
+
         if (dbAppearance) {
           setCharacterAppearance(dbAppearance);
         } else {
-          // Fallback to localStorage
-          const localAppearance = loadCharacterAppearance();
-          setCharacterAppearance(localAppearance);
+          // Use default appearance
+          const defaultAppearance = loadCharacterAppearance();
+          setCharacterAppearance(defaultAppearance);
         }
       } catch (error) {
         console.error('Error loading character appearance:', error);
-        // Use default appearance
         const defaultAppearance = loadCharacterAppearance();
         setCharacterAppearance(defaultAppearance);
       }

--- a/apps/web/src/components/GameLayout.tsx
+++ b/apps/web/src/components/GameLayout.tsx
@@ -50,6 +50,7 @@ export default function GameLayout({
         if (dbAppearance) {
           setCharacterAppearance(dbAppearance);
         } else {
+          console.warn('No character appearance found in database, using defaults');
           // Use default appearance
           const defaultAppearance = loadCharacterAppearance();
           setCharacterAppearance(defaultAppearance);

--- a/apps/web/src/lib/sprites/characterDatabase.ts
+++ b/apps/web/src/lib/sprites/characterDatabase.ts
@@ -1,4 +1,18 @@
 import { CharacterAppearance } from './characterSprites';
+import { supabase } from '../supabaseClient';
+
+// Utility to get the current user's access token
+async function getAccessToken(): Promise<string> {
+  const { data, error } = await supabase.auth.getSession();
+  if (error) {
+    throw new Error(`Auth session error: ${error.message}`);
+  }
+  const token = data.session?.access_token;
+  if (!token) {
+    throw new Error('No auth token found');
+  }
+  return token;
+}
 
 // Functions for saving/loading character appearance directly from the backend database
 
@@ -7,16 +21,7 @@ export async function saveCharacterToDatabase(
   userId?: string
 ): Promise<void> {
   try {
-    // Get the auth token from localStorage (Supabase stores it there)
-    const token =
-      localStorage.getItem('supabase.auth.token') ||
-      JSON.parse(
-        localStorage.getItem('sb-apoboundupzmulkqxkxw-auth-token') || '{}'
-      )?.access_token;
-
-    if (!token) {
-      throw new Error('No auth token found');
-    }
+    const token = await getAccessToken();
 
     const response = await fetch('/api/user/avatar', {
       method: 'POST',
@@ -44,16 +49,7 @@ export async function loadCharacterFromDatabase(
   userId?: string
 ): Promise<CharacterAppearance | null> {
   try {
-    // Get the auth token from localStorage
-    const token =
-      localStorage.getItem('supabase.auth.token') ||
-      JSON.parse(
-        localStorage.getItem('sb-apoboundupzmulkqxkxw-auth-token') || '{}'
-      )?.access_token;
-
-    if (!token) {
-      throw new Error('No auth token found');
-    }
+    const token = await getAccessToken();
 
     const response = await fetch('/api/user/avatar', {
       method: 'GET',

--- a/apps/web/src/lib/sprites/characterDatabase.ts
+++ b/apps/web/src/lib/sprites/characterDatabase.ts
@@ -1,51 +1,42 @@
 import { CharacterAppearance } from './characterSprites';
 
-// This would be used with Prisma client in a server environment
-// For now, we'll use localStorage but structure it for future database integration
-
-export interface DBCharacterAppearance extends CharacterAppearance {
-  userId?: string;
-  profileId?: string;
-  characterId?: string;
-}
+// Functions for saving/loading character appearance directly from the backend database
 
 export async function saveCharacterToDatabase(
   appearance: CharacterAppearance,
   userId?: string
 ): Promise<void> {
-  // Save to localStorage for immediate access
-  const dbAppearance: DBCharacterAppearance = {
-    ...appearance,
-    userId
-  };
-  localStorage.setItem('character_appearance_db', JSON.stringify(dbAppearance));
-  
-  // Save to database via API
   try {
     // Get the auth token from localStorage (Supabase stores it there)
-    const token = localStorage.getItem('supabase.auth.token') || 
-                  JSON.parse(localStorage.getItem('sb-apoboundupzmulkqxkxw-auth-token') || '{}')?.access_token;
-    
-    if (token) {
-      const response = await fetch('/api/user/avatar', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
-        },
-        body: JSON.stringify({
-          avatar: appearance,
-          display: appearance.name
-        })
-      });
+    const token =
+      localStorage.getItem('supabase.auth.token') ||
+      JSON.parse(
+        localStorage.getItem('sb-apoboundupzmulkqxkxw-auth-token') || '{}'
+      )?.access_token;
 
-      if (!response.ok) {
-        console.error('Failed to save avatar to database:', await response.text());
-      }
+    if (!token) {
+      throw new Error('No auth token found');
+    }
+
+    const response = await fetch('/api/user/avatar', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify({
+        avatar: appearance,
+        display: appearance.name
+      })
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(text || 'Failed to save avatar to database');
     }
   } catch (error) {
     console.error('Error saving character to database:', error);
-    // Don't throw - localStorage save was successful
+    throw error;
   }
 }
 
@@ -54,65 +45,41 @@ export async function loadCharacterFromDatabase(
 ): Promise<CharacterAppearance | null> {
   try {
     // Get the auth token from localStorage
-    const token = localStorage.getItem('supabase.auth.token') || 
-                  JSON.parse(localStorage.getItem('sb-apoboundupzmulkqxkxw-auth-token') || '{}')?.access_token;
-    
-    if (token) {
-      const response = await fetch('/api/user/avatar', {
-        method: 'GET',
-        headers: {
-          'Authorization': `Bearer ${token}`
-        }
-      });
+    const token =
+      localStorage.getItem('supabase.auth.token') ||
+      JSON.parse(
+        localStorage.getItem('sb-apoboundupzmulkqxkxw-auth-token') || '{}'
+      )?.access_token;
 
-      if (response.ok) {
-        const data = await response.json();
-        if (data.avatar) {
-          // Save to localStorage for offline access
-          const appearance = {
-            name: data.avatar.name || data.display || 'Trader',
-            base: data.avatar.base || 'v01',
-            outfit: data.avatar.outfit || 'fstr_v01',
-            hair: data.avatar.hair || 'bob1_v01',
-            hat: data.avatar.hat || ''
-          };
-          localStorage.setItem('character_appearance_db', JSON.stringify(appearance));
-          return appearance;
-        }
+    if (!token) {
+      throw new Error('No auth token found');
+    }
+
+    const response = await fetch('/api/user/avatar', {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`
       }
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(text || 'Failed to load avatar from database');
+    }
+
+    const data = await response.json();
+    if (data.avatar) {
+      return {
+        name: data.avatar.name || data.display || 'Trader',
+        base: data.avatar.base || 'v01',
+        outfit: data.avatar.outfit || 'fstr_v01',
+        hair: data.avatar.hair || 'bob1_v01',
+        hat: data.avatar.hat || ''
+      };
     }
   } catch (error) {
     console.error('Error loading character from database:', error);
   }
-  
-  // Fallback to localStorage
-  const saved = localStorage.getItem('character_appearance_db');
-  if (saved) {
-    const dbAppearance: DBCharacterAppearance = JSON.parse(saved);
-    return {
-      name: dbAppearance.name,
-      base: dbAppearance.base,
-      outfit: dbAppearance.outfit,
-      hair: dbAppearance.hair,
-      hat: dbAppearance.hat
-    };
-  }
-  
-  return null;
-}
 
-// Migration helper to move localStorage data to database format
-export function migrateLocalStorageToDatabase(): CharacterAppearance | null {
-  const oldFormat = localStorage.getItem('character_appearance');
-  if (!oldFormat) return null;
-  
-  try {
-    const appearance = JSON.parse(oldFormat);
-    // Save in new database format
-    saveCharacterToDatabase(appearance);
-    return appearance;
-  } catch (error) {
-    console.warn('Failed to migrate character appearance:', error);
-    return null;
-  }
+  return null;
 }

--- a/apps/web/src/lib/sprites/characterOptions.ts
+++ b/apps/web/src/lib/sprites/characterOptions.ts
@@ -81,33 +81,14 @@ export const CHARACTER_OPTIONS = {
   ],
 };
 
-import { saveCharacterToDatabase, loadCharacterFromDatabase, migrateLocalStorageToDatabase } from './characterDatabase';
+import { saveCharacterToDatabase, loadCharacterFromDatabase } from './characterDatabase';
 import { CharacterAppearance } from './characterSprites';
 
 export async function saveCharacterAppearance(appearance: CharacterAppearance) {
-  // Save to both localStorage (immediate) and database (future)
-  localStorage.setItem('character_appearance', JSON.stringify(appearance));
   await saveCharacterToDatabase(appearance);
 }
 
 export function loadCharacterAppearance(): CharacterAppearance {
-  // Try to load from localStorage first
-  const saved = localStorage.getItem('character_appearance');
-  if (saved) {
-    try {
-      return JSON.parse(saved);
-    } catch (error) {
-      console.warn('Failed to parse saved character appearance:', error);
-    }
-  }
-  
-  // Try to migrate old data
-  const migrated = migrateLocalStorageToDatabase();
-  if (migrated) {
-    return migrated;
-  }
-  
-  // Default appearance
   return {
     name: 'Trader',
     base: 'v01',
@@ -117,15 +98,13 @@ export function loadCharacterAppearance(): CharacterAppearance {
   };
 }
 
-export async function loadCharacterAppearanceAsync(userId?: string): Promise<CharacterAppearance> {
-  // Try to load from database first
-  if (userId) {
-    const dbAppearance = await loadCharacterFromDatabase(userId);
-    if (dbAppearance) {
-      return dbAppearance;
-    }
+export async function loadCharacterAppearanceAsync(
+  userId?: string
+): Promise<CharacterAppearance> {
+  const dbAppearance = await loadCharacterFromDatabase(userId);
+  if (dbAppearance) {
+    return dbAppearance;
   }
-  
-  // Fallback to synchronous load
+
   return loadCharacterAppearance();
 }


### PR DESCRIPTION
## Summary
- remove localStorage from character persistence and rely solely on database
- improve database save/load error handling
- load character appearance from database in creator and game layout

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689a3a5f31348331a8cbc0b2fdf8e44c