### PR TITLE
feat: add username-based auth

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,11 +1,19 @@
 'use client';
 import { supabase } from '../lib/supabaseClient';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, FormEvent } from 'react';
 import './page.css';
 
 export default function Home() {
   const [user, setUser] = useState<any>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [authMode, setAuthMode] = useState<'none' | 'signup' | 'login'>('none');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [username, setUsername] = useState('');
+  const [identifier, setIdentifier] = useState('');
+  const [errorMsg, setErrorMsg] = useState('');
+  const [needsUsername, setNeedsUsername] = useState(false);
+  const [newUsername, setNewUsername] = useState('');
 
   useEffect(() => {
     supabase.auth.getUser().then(({ data }) => {
@@ -14,44 +22,54 @@ export default function Home() {
     });
   }, []);
 
-  async function signUp() {
-    const email = prompt('Enter your email:') || '';
-    const password = prompt('Create a password:') || '';
-    const username = prompt('Choose a username:') || '';
-    if (!email || !password || !username) return;
+  function validateUsername(name: string) {
+    return /^[a-zA-Z0-9_]{3,20}$/.test(name);
+  }
 
-    const { data: existing } = await supabase
-      .from('Profile')
-      .select('id')
-      .eq('display', username);
-    if (existing && existing.length > 0) {
-      alert('Username already taken.');
+  async function handleSignUp(e: FormEvent) {
+    e.preventDefault();
+    setErrorMsg('');
+    if (!validateUsername(username)) {
+      setErrorMsg('Username must be 3-20 characters and contain only letters, numbers, or _.');
       return;
     }
-
-    const { data, error } = await supabase.auth.signUp({
-      email,
-      password,
-    });
+    if (password.length < 8) {
+      setErrorMsg('Password must be at least 8 characters.');
+      return;
+    }
+    const { data, error } = await supabase.auth.signUp({ email, password });
     if (error) {
-      alert(error.message);
+      setErrorMsg('Sign up failed.');
       return;
     }
-    const user = data.user;
-    if (user) {
-      await supabase.from('Profile').upsert({
-        userId: user.id,
-        display: username,
-      });
-      alert('Account created! Please verify your email before logging in.');
+    const u = data.user;
+    if (u) {
+      const { error: profileError } = await supabase
+        .from('Profile')
+        .upsert({ userId: u.id, display: username });
+      if (profileError) {
+        if ((profileError as any).code === '23505') {
+          setErrorMsg('Username already taken.');
+        } else {
+          setErrorMsg('Failed to save profile.');
+        }
+        return;
+      }
+      setErrorMsg('Account created! Check your email to verify before logging in.');
+      setEmail('');
+      setPassword('');
+      setUsername('');
+      setAuthMode('login');
     }
   }
 
-  async function signIn() {
-    const identifier = prompt('Enter email or username:') || '';
-    const password = prompt('Enter your password:') || '';
-    if (!identifier || !password) return;
-
+  async function handleSignIn(e: FormEvent) {
+    e.preventDefault();
+    setErrorMsg('');
+    if (!identifier || !password) {
+      setErrorMsg('Missing credentials.');
+      return;
+    }
     let authResponse;
     if (identifier.includes('@')) {
       authResponse = await supabase.auth.signInWithPassword({
@@ -59,35 +77,24 @@ export default function Home() {
         password,
       });
     } else {
-      const { data: profile, error: profileError } = await supabase
+      const { data: profileUser, error } = await supabase
         .from('Profile')
-        .select('userId')
+        .select('user:User(email)')
         .eq('display', identifier)
         .single();
-      if (profileError || !profile) {
-        alert('User not found.');
-        return;
-      }
-      const { data: userRow, error: userError } = await supabase
-        .from('User')
-        .select('email')
-        .eq('id', profile.userId)
-        .single();
-      if (userError || !userRow) {
-        alert('User not found.');
+      if (error || !profileUser?.user?.email) {
+        setErrorMsg('Invalid credentials.');
         return;
       }
       authResponse = await supabase.auth.signInWithPassword({
-        email: userRow.email,
+        email: profileUser.user.email,
         password,
       });
     }
-
     if (authResponse.error) {
-      alert(authResponse.error.message);
+      setErrorMsg('Invalid credentials.');
       return;
     }
-
     const loggedInUser = authResponse.data.user;
     if (loggedInUser) {
       const { data: prof } = await supabase
@@ -96,29 +103,42 @@ export default function Home() {
         .eq('userId', loggedInUser.id)
         .single();
       if (!prof || !prof.display || prof.display === 'Trader') {
-        const newName = prompt('Choose a username:') || '';
-        if (newName) {
-          const { data: existingName } = await supabase
-            .from('Profile')
-            .select('id')
-            .eq('display', newName);
-          if (existingName && existingName.length > 0) {
-            alert('Username already taken.');
-          } else {
-            await supabase.from('Profile').upsert({
-              userId: loggedInUser.id,
-              display: newName,
-            });
-          }
-        }
+        setNeedsUsername(true);
       }
       setUser(loggedInUser);
+      setAuthMode('none');
+      setIdentifier('');
+      setPassword('');
     }
+  }
+
+  async function saveUsername(e: FormEvent) {
+    e.preventDefault();
+    setErrorMsg('');
+    if (!validateUsername(newUsername)) {
+      setErrorMsg('Username must be 3-20 characters and contain only letters, numbers, or _.');
+      return;
+    }
+    const { error } = await supabase
+      .from('Profile')
+      .upsert({ userId: user.id, display: newUsername });
+    if (error) {
+      if ((error as any).code === '23505') {
+        setErrorMsg('Username already taken.');
+      } else {
+        setErrorMsg('Failed to save username.');
+      }
+      return;
+    }
+    setNeedsUsername(false);
+    setNewUsername('');
+    setUser({ ...user });
   }
 
   async function signOut() {
     await supabase.auth.signOut();
     setUser(null);
+    setAuthMode('none');
   }
 
   return (
@@ -187,37 +207,129 @@ export default function Home() {
         {isLoading ? (
           <div className="auth-status">Loading...</div>
         ) : user ? (
-          <div className="logged-in-section">
-            <div className="auth-status">
-              Trading as <strong>{user.email}</strong>
-              <button onClick={signOut} className="btn-secondary">Sign Out</button>
+          needsUsername ? (
+            <div className="sign-up-section">
+              <h2>Choose a Username</h2>
+              <form onSubmit={saveUsername} className="auth-form">
+                <input
+                  value={newUsername}
+                  onChange={(e) => setNewUsername(e.target.value)}
+                  placeholder="Username"
+                  required
+                />
+                <button type="submit" className="btn-primary btn-large">
+                  Save
+                </button>
+              </form>
+              {errorMsg && <p className="auth-error">{errorMsg}</p>}
             </div>
-            <h2>Continue Your Journey</h2>
-            <div className="quick-links">
-              <a href="/warehouse" className="btn-primary">📦 Warehouse</a>
-              <a href="/auction" className="btn-primary">💰 Auction House</a>
-              <a href="/missions" className="btn-primary">🗺️ Missions</a>
-              <a href="/crafting" className="btn-primary">🔨 Crafting</a>
+          ) : (
+            <div className="logged-in-section">
+              <div className="auth-status">
+                Trading as <strong>{user.email}</strong>
+                <button onClick={signOut} className="btn-secondary">Sign Out</button>
+              </div>
+              <h2>Continue Your Journey</h2>
+              <div className="quick-links">
+                <a href="/warehouse" className="btn-primary">📦 Warehouse</a>
+                <a href="/auction" className="btn-primary">💰 Auction House</a>
+                <a href="/missions" className="btn-primary">🗺️ Missions</a>
+                <a href="/crafting" className="btn-primary">🔨 Crafting</a>
+              </div>
+              <div className="secondary-links">
+                <a href="/profile">Profile</a>
+                <a href="/contracts">Contracts</a>
+                <a href="/hub">Trading Hub</a>
+                <a href="/creator">Character Creator</a>
+              </div>
             </div>
-            <div className="secondary-links">
-              <a href="/profile">Profile</a>
-              <a href="/contracts">Contracts</a>
-              <a href="/hub">Trading Hub</a>
-              <a href="/creator">Character Creator</a>
-            </div>
-          </div>
+          )
         ) : (
           <div className="sign-up-section">
             <h2>Begin Your Trading Legacy</h2>
             <p>Join the frontier. Build trade routes. Shape the new world.</p>
-            <div className="auth-buttons">
-              <button onClick={signUp} className="btn-primary btn-large">
-                Sign Up
-              </button>
-              <button onClick={signIn} className="btn-secondary btn-large">
-                Log In
-              </button>
-            </div>
+            {authMode === 'signup' ? (
+              <form onSubmit={handleSignUp} className="auth-form">
+                <input
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="Email"
+                  required
+                />
+                <input
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="Password"
+                  required
+                />
+                <input
+                  value={username}
+                  onChange={(e) => setUsername(e.target.value)}
+                  placeholder="Username"
+                  required
+                />
+                <button type="submit" className="btn-primary btn-large">
+                  Create Account
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setAuthMode('none');
+                    setErrorMsg('');
+                  }}
+                  className="btn-secondary btn-large"
+                >
+                  Cancel
+                </button>
+              </form>
+            ) : authMode === 'login' ? (
+              <form onSubmit={handleSignIn} className="auth-form">
+                <input
+                  value={identifier}
+                  onChange={(e) => setIdentifier(e.target.value)}
+                  placeholder="Email or Username"
+                  required
+                />
+                <input
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="Password"
+                  required
+                />
+                <button type="submit" className="btn-primary btn-large">
+                  Log In
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setAuthMode('none');
+                    setErrorMsg('');
+                  }}
+                  className="btn-secondary btn-large"
+                >
+                  Cancel
+                </button>
+              </form>
+            ) : (
+              <div className="auth-buttons">
+                <button
+                  onClick={() => setAuthMode('signup')}
+                  className="btn-primary btn-large"
+                >
+                  Sign Up
+                </button>
+                <button
+                  onClick={() => setAuthMode('login')}
+                  className="btn-secondary btn-large"
+                >
+                  Log In
+                </button>
+              </div>
+            )}
+            {errorMsg && <p className="auth-error">{errorMsg}</p>}
           </div>
         )}
       </section>

--- a/prisma/migrations/20250809143551_unique_profile_display/migration.sql
+++ b/prisma/migrations/20250809143551_unique_profile_display/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."Profile" ADD CONSTRAINT "Profile_display_key" UNIQUE ("display");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -73,7 +73,7 @@ model User {
 model Profile {
   id        String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   userId    String   @unique @db.Uuid
-  display   String   @default("Trader")
+  display   String   @unique @default("Trader")
   avatar    Json? // store creator selections (colors, parts)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt


### PR DESCRIPTION
## Summary
- allow sign up with email, password, and unique username
- support login using email or username/password and prompt for missing usernames
- enforce unique profile display names in schema

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689a83341d088331bf3c43b1cdeeb823