### PR TITLE
Add UI/UX feedback study system

### DIFF
--- a/apps/web/feedback/.gitignore
+++ b/apps/web/feedback/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -7,13 +7,19 @@
       "name": "aurelian-web",
       "dependencies": {
         "@prisma/client": "^6.13.0",
+        "@radix-ui/react-slot": "^1.2.3",
         "@supabase/supabase-js": "^2.45.0",
         "@tanstack/react-query": "^5.84.2",
         "@tanstack/react-query-devtools": "^5.84.2",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
         "colyseus.js": "^0.15.17",
+        "lucide-react": "^0.539.0",
         "next": "^14.2.5",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "tailwind-merge": "^3.3.1",
+        "zod": "^4.0.17"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.4",
@@ -487,6 +493,39 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.38",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.38.tgz",
@@ -812,14 +851,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1000,11 +1039,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -1069,7 +1129,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -1541,6 +1601,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/lucide-react": {
+      "version": "0.539.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.539.0.tgz",
+      "integrity": "sha512-VVISr+VF2krO91FeuCrm1rSOLACQUYVy7NQkzrOty52Y8TlTPcXcMdQFj9bYzBgXbWCiywlwSZ3Z8u6a+6bMlg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -1950,6 +2019,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tailwind-merge": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
+      "integrity": "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
     "node_modules/tldts": {
       "version": "6.1.86",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
@@ -2135,6 +2214,15 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.17.tgz",
+      "integrity": "sha512-1PHjlYRevNxxdy2JZ8JcNAw7rX8V9P1AKkP+x/xZfxB0K5FYfuV+Ug6P/6NVSR2jHQ+FzDDoDHS04nYUsOIyLQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -26,7 +26,8 @@
     "next": "^14.2.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "tailwind-merge": "^3.3.1"
+    "tailwind-merge": "^3.3.1",
+    "zod": "^4.0.17"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.4",

--- a/apps/web/src/app/api/feedback/route.ts
+++ b/apps/web/src/app/api/feedback/route.ts
@@ -2,13 +2,40 @@ export const runtime = "nodejs";
 import { NextResponse } from 'next/server';
 import { promises as fs } from 'fs';
 import path from 'path';
+import { z, ZodError } from 'zod';
+
+const MAX_SIZE = 100 * 1024; // 100KB
+
+const answerSchema = z.object({
+  style: z.string().max(1000),
+  lookFeel: z.string().max(1000),
+  understanding: z.string().max(1000),
+  other: z.string().max(1000)
+});
+
+const feedbackSchema = z.record(z.string().url(), answerSchema);
 
 export async function POST(req: Request) {
-  const data = await req.json();
-  const dir = path.join(process.cwd(), 'feedback');
-  await fs.mkdir(dir, { recursive: true });
-  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-  const filePath = path.join(dir, `${timestamp}.json`);
-  await fs.writeFile(filePath, JSON.stringify(data, null, 2));
-  return NextResponse.json({ ok: true });
+  try {
+    const len = Number(req.headers.get('content-length') ?? '0');
+    if (len > MAX_SIZE) {
+      return NextResponse.json({ error: 'Payload too large' }, { status: 413 });
+    }
+
+    const json = await req.json();
+    const data = feedbackSchema.parse(json);
+
+    const dir = path.join(process.cwd(), 'feedback');
+    await fs.mkdir(dir, { recursive: true });
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const filePath = path.join(dir, `${timestamp}.json`);
+    await fs.writeFile(filePath, JSON.stringify(data, null, 2));
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error(err);
+    const status = err instanceof ZodError ? 400 : 500;
+    const message = err instanceof ZodError ? 'Invalid feedback format' : 'Failed to save feedback';
+    return NextResponse.json({ error: message }, { status });
+  }
 }

--- a/apps/web/src/app/api/feedback/route.ts
+++ b/apps/web/src/app/api/feedback/route.ts
@@ -1,0 +1,14 @@
+export const runtime = "nodejs";
+import { NextResponse } from 'next/server';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export async function POST(req: Request) {
+  const data = await req.json();
+  const dir = path.join(process.cwd(), 'feedback');
+  await fs.mkdir(dir, { recursive: true });
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const filePath = path.join(dir, `${timestamp}.json`);
+  await fs.writeFile(filePath, JSON.stringify(data, null, 2));
+  return NextResponse.json({ ok: true });
+}

--- a/apps/web/src/app/feedback/page.tsx
+++ b/apps/web/src/app/feedback/page.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+
+type PageInfo = {
+  name: string;
+  url: string;
+};
+
+const PAGES: PageInfo[] = [
+  { name: 'Landing Page', url: 'https://www.aurelian.online/' },
+  { name: 'Trading Hub', url: 'https://www.aurelian.online/hub' },
+  { name: 'Character Creator', url: 'https://www.aurelian.online/creator' },
+  { name: 'Warehouse', url: 'https://www.aurelian.online/warehouse' },
+  { name: 'Inventory', url: 'https://www.aurelian.online/inventory' },
+  { name: 'Auction House', url: 'https://www.aurelian.online/auction' },
+  { name: 'Market Dashboard', url: 'https://www.aurelian.online/market' },
+  { name: 'Trade Contracts', url: 'https://www.aurelian.online/contracts' },
+  { name: 'Mission Control', url: 'https://www.aurelian.online/missions' },
+  { name: 'Agents', url: 'https://www.aurelian.online/agents' },
+  { name: 'Crafting Workshop', url: 'https://www.aurelian.online/crafting' },
+  { name: 'Hub Travel', url: 'https://www.aurelian.online/hub-travel' },
+  { name: 'Guild Main', url: 'https://www.aurelian.online/guild' },
+  { name: 'Guild Browse', url: 'https://www.aurelian.online/guild/browse' },
+  { name: 'Guild Create', url: 'https://www.aurelian.online/guild/create' },
+  { name: 'Guild Members', url: 'https://www.aurelian.online/guild/members' },
+  { name: 'Guild Manage', url: 'https://www.aurelian.online/guild/manage' },
+  { name: 'Guild Warehouse', url: 'https://www.aurelian.online/guild/warehouse' },
+  { name: 'Guild Wars', url: 'https://www.aurelian.online/guild/wars' },
+  { name: 'Guild Achievements', url: 'https://www.aurelian.online/guild/achievements' },
+  { name: 'Guild Channels', url: 'https://www.aurelian.online/guild/channels' },
+  { name: 'Mission Statistics', url: 'https://www.aurelian.online/missions/stats' },
+  { name: 'Mission Leaderboard', url: 'https://www.aurelian.online/missions/leaderboard' },
+  { name: 'User Profile', url: 'https://www.aurelian.online/profile' },
+  { name: 'Help', url: 'https://www.aurelian.online/help' },
+  { name: 'World Map', url: 'https://www.aurelian.online/world-map' }
+];
+
+const QUESTIONS = [
+  { id: 'style', label: 'What do you think about the style and design?' },
+  { id: 'lookFeel', label: 'How does the look and feel support the experience?' },
+  { id: 'understanding', label: 'Was the page easy to understand?' },
+  { id: 'other', label: 'Any other feedback or suggestions?' }
+];
+
+export default function FeedbackPage() {
+  const [index, setIndex] = useState(0);
+  const [responses, setResponses] = useState<Record<string, Record<string, string>>>({});
+  const [done, setDone] = useState(false);
+
+  const page = PAGES[index];
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    const answer: Record<string, string> = {};
+    QUESTIONS.forEach(q => {
+      answer[q.id] = (formData.get(q.id) as string) || '';
+    });
+    const newResponses = { ...responses, [page.url]: answer };
+    setResponses(newResponses);
+    e.currentTarget.reset();
+    if (index + 1 < PAGES.length) {
+      setIndex(index + 1);
+    } else {
+      await fetch('/api/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(newResponses)
+      });
+      setDone(true);
+    }
+  };
+
+  if (done) {
+    return <div className="p-4">Thank you for your feedback!</div>;
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">UI/UX Feedback Study</h1>
+      <p>
+        Reviewing page {index + 1} of {PAGES.length}: {page.name}
+      </p>
+      <iframe
+        src={page.url}
+        title={page.name}
+        className="w-full h-96 border"
+      />
+      <form onSubmit={handleSubmit} className="space-y-2">
+        {QUESTIONS.map(q => (
+          <label key={q.id} className="block">
+            <span className="block font-medium">{q.label}</span>
+            <textarea
+              name={q.id}
+              required
+              className="mt-1 w-full border p-2"
+            />
+          </label>
+        ))}
+        <button
+          type="submit"
+          className="mt-2 rounded bg-blue-600 px-4 py-2 font-semibold text-white"
+        >
+          {index + 1 < PAGES.length ? 'Next' : 'Submit'}
+        </button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `/feedback` page guiding users through game pages and recording comments
- Save collected responses server-side via `/api/feedback` route to timestamped files

## Testing
- `npm run lint:web` *(fails: Unknown options removed in new ESLint)*
- `npm run typecheck:web` *(fails: existing type errors in project)*
- `npm run test:web` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689ff239b0288331a997e710bd2bfec2