### PR TITLE
fix: use real timers and avoid test intervals

### DIFF
--- a/apps/web/jest.setup.cjs
+++ b/apps/web/jest.setup.cjs
@@ -209,8 +209,10 @@ jest.mock('@prisma/client', () => ({
   }
 }));
 
-// Mock timers globally to prevent real setInterval/setTimeout from running
-jest.useFakeTimers();
+// Use real timers by default so tests relying on actual timing
+// behavior (e.g. setTimeout in async flows) function correctly.
+// Individual tests can still switch to fake timers when needed.
+jest.useRealTimers();
 
 // Setup test cleanup to prevent async leaks
 beforeEach(() => {

--- a/apps/web/src/lib/apiUtils.ts
+++ b/apps/web/src/lib/apiUtils.ts
@@ -266,15 +266,19 @@ export function checkRateLimit(
   return { allowed: true };
 }
 
-// Clean up expired rate limit entries
-setInterval(() => {
-  const now = Date.now();
-  for (const [key, value] of rateLimitStore.entries()) {
-    if (now > value.resetTime) {
-      rateLimitStore.delete(key);
+// Clean up expired rate limit entries.
+// Avoid running this interval during tests to prevent open handles
+// that keep Jest from exiting.
+if (process.env.NODE_ENV !== 'test') {
+  setInterval(() => {
+    const now = Date.now();
+    for (const [key, value] of rateLimitStore.entries()) {
+      if (now > value.resetTime) {
+        rateLimitStore.delete(key);
+      }
     }
-  }
-}, 60000); // Clean up every minute
+  }, 60000); // Clean up every minute
+}
 
 // Common guild member formatting
 export function formatGuildMember(member: any) {


### PR DESCRIPTION
## Summary
- use real timers in test setup so async flows complete
- skip rate limit cleanup interval during tests to avoid open handles

## Testing
- `npm test src/__tests__/database/transaction-logic.test.ts`
- `npm test` *(fails: 5 failed, 6 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e495c35c83319b6aa39b4bed71fc