### PR TITLE
Fix login redirect to existing page and support auth mode param

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -17,6 +17,15 @@ export default function Home() {
   const [needsUsername, setNeedsUsername] = useState(false);
   const [newUsername, setNewUsername] = useState('');
 
+  // Allow external redirects to specify auth mode via query parameter
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const auth = params.get('auth');
+    if (auth === 'login' || auth === 'signup' || auth === 'reset') {
+      setAuthMode(auth);
+    }
+  }, []);
+
   useEffect(() => {
     // Handle OAuth implicit flow tokens from URL fragment
     const handleImplicitAuth = async () => {

--- a/apps/web/src/lib/query-client.ts
+++ b/apps/web/src/lib/query-client.ts
@@ -16,7 +16,8 @@ const globalErrorHandler = (error: unknown) => {
     if (status === 401) {
       // Redirect to login or refresh token
       if (typeof window !== 'undefined') {
-        window.location.href = '/auth/login';
+        // Root page handles auth mode via query parameter
+        window.location.href = '/?auth=login';
       }
     }
   }


### PR DESCRIPTION
## Summary
- Redirect React Query auth errors to `/?auth=login` instead of missing `/auth/login`
- Allow passing `auth` query parameter on the landing page to preselect login/signup/reset modes

## Testing
- `npm run lint:web`
- `npm run typecheck:web` *(fails: Property 'itemDef' does not exist on type ...)*
- `npm run test:web` *(fails: Test Suites: 5 failed, 6 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bafa67c3288331b5a656d198528494